### PR TITLE
Also pass positional arguments along to ConnectionDurableDict

### DIFF
--- a/durabledict/redis.py
+++ b/durabledict/redis.py
@@ -14,8 +14,8 @@ class RedisDict(ConnectionDurableDict):
         >>> 'bar' #doctest: +SKIP
     """
 
-    def __init__(self, **kwargs):
-        super(RedisDict, self).__init__(**kwargs)
+    def __init__(self, *args, **kwargs):
+        super(RedisDict, self).__init__(*args, **kwargs)
         self.__touch_last_updated()
 
     def persist(self, key, value):

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -353,6 +353,9 @@ class TestRedisDict(BaseTest, AutoSyncTrueTest, RedisTest, unittest.TestCase):
                                     self.dict.persist, 'foo', 'bar')
             self.assertFalse(self.hget('foo'))
 
+    def test_can_instantiate_without_keywords(self):
+        RedisDict(self.keyspace, Redis())
+
 
 class TestModelDict(BaseTest, AutoSyncTrueTest, ModelDictTest, unittest.TestCase):
 


### PR DESCRIPTION
Otherwise, the preceding promise can't be kept:

    Functions just like you'd expect it::

        mydict = RedisDict('my_redis_key', Redis())
        mydict['test']
        >>> 'bar' #doctest: +SKIP

Both arguments are positional. This actually throws a:

    TypeError: __init__() takes exactly 1 argument (3 given)