### PR TITLE
Add __eq__ method to storage

### DIFF
--- a/durabledict/base.py
+++ b/durabledict/base.py
@@ -70,9 +70,14 @@ class DurableDict(object):
         self.__sync_with_durable_storage()
         return self.__dict.__len__()
 
+    # NOTE: This function is unused in python 3 and should be removed.
     def __cmp__(self, other):
         self.__sync_with_durable_storage()
         return self.__dict.__cmp__(other)
+
+    def __eq__(self, other):
+        self.__sync_with_durable_storage()
+        return self.__dict == other
 
     def __repr__(self):
         return self.__dict.__repr__()

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 
 setup(
     name='durabledict',
-    version='0.9.3',
+    version='0.9.4',
     author='DISQUS',
     author_email='opensource@disqus.com',
     url='http://github.com/disqus/durabledict/',


### PR DESCRIPTION
I need this to get tests passing on gutter branch `python3`.

This is adding in python 3 behavior for equality. On python2 this was handled by the `__cmp__` method.

[Reference](https://portingguide.readthedocs.io/en/latest/comparisons.html)